### PR TITLE
Clearing guid string.

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -95,6 +95,7 @@ namespace ofxLibdc {
             
             ss << hex << deviceList.back().guidInt;
             deviceList.back().guid = ss.str();
+            ss.str("");
             ss.clear();
         }
         


### PR DESCRIPTION
`.str("")` actually clears the string.
`.clear()` clears stream errors and allows writing to the stream again.

I was seeing that when you 'discovered cameras' the first guid would be good, and the second guid would be a concatenation of both guids.